### PR TITLE
Fix users pagination

### DIFF
--- a/models/wsModels/WSActiveRecord.php
+++ b/models/wsModels/WSActiveRecord.php
@@ -106,7 +106,7 @@ abstract class WSActiveRecord extends \yii\base\Model {
      */
     public function find($sessionToken, $attributes) {
         $requestRes = $this->wsModel->get($sessionToken, "", $attributes);
-//        var_dump($requestRes);exit;
+
         if (isset($requestRes->{WSConstants::METADATA}->{WSConstants::PAGINATION})) {
             $this->totalPages = $requestRes->{WSConstants::METADATA}->{WSConstants::PAGINATION}->{WSConstants::TOTAL_PAGES};
             $this->totalCount = $requestRes->{WSConstants::METADATA}->{WSConstants::PAGINATION}->{WSConstants::TOTAL_COUNT};

--- a/models/wsModels/WSActiveRecord.php
+++ b/models/wsModels/WSActiveRecord.php
@@ -18,6 +18,8 @@ namespace app\models\wsModels;
  * @author Morgane Vidal <morgane.vidal@inra.fr>, Arnaud Charleroy <arnaud.charleroy@inra.fr>
  * @update [Arnaud Charleroy] 14 September, 2018 : Fix totalCount attribute when only 
  *                                                 one element is returned 
+ * @update [Arnaud Charleroy] 26 September, 2018 : Fix pageSize showed when only 
+ *                                                 one element is returned 
  */
 abstract class WSActiveRecord extends \yii\base\Model {
     
@@ -104,7 +106,7 @@ abstract class WSActiveRecord extends \yii\base\Model {
      */
     public function find($sessionToken, $attributes) {
         $requestRes = $this->wsModel->get($sessionToken, "", $attributes);
-
+//        var_dump($requestRes);exit;
         if (isset($requestRes->{WSConstants::METADATA}->{WSConstants::PAGINATION})) {
             $this->totalPages = $requestRes->{WSConstants::METADATA}->{WSConstants::PAGINATION}->{WSConstants::TOTAL_PAGES};
             $this->totalCount = $requestRes->{WSConstants::METADATA}->{WSConstants::PAGINATION}->{WSConstants::TOTAL_COUNT};
@@ -114,6 +116,8 @@ abstract class WSActiveRecord extends \yii\base\Model {
             //SILEX:info
             // A null pagination means only one result
             //\SILEX:info
+            $this->page = 0;
+            $this->pageSize = 1;
             $this->totalCount = 1;
         }
         

--- a/models/yiiModels/UserSearch.php
+++ b/models/yiiModels/UserSearch.php
@@ -18,8 +18,10 @@ use app\models\wsModels\WSConstants;
  * Based on the Yii2 Search basic classes
  * @author Morgane Vidal <morgane.vidal@inra.fr>, Arnaud Charleroy <arnaud.charleroy@inra.fr>
  * @update [Arnaud Charleroy] 19 September, 2018 : Pagination fixed
+ * @update [Arnaud Charleroy] 26 September, 2018 : Pagination fixed
  */
 class UserSearch extends YiiUserModel {
+    
     //SILEX:refactor
     //create a trait (?) with methods search and jsonListOfArray and use it in 
     //each class ElementNameSearch
@@ -42,18 +44,18 @@ class UserSearch extends YiiUserModel {
      *               or string \app\models\wsModels\WSConstants::TOKEN if the user needs to log in
      */
     public function search($sessionToken, $params) {
-        //1. load the searched params 
+        //1. Load the searched params 
         $this->load($params);
-        if (isset($params[YiiModelsConstants::PAGE])) {
-            $this->page = $params[YiiModelsConstants::PAGE];
-        }
+ 
+        //2. Check search parameters
+        $this->checkParameters($params);
         
-        //2. Check validity of search data
+        //3. Check validity of search data
         if (!$this->validate()) {
             return new \yii\data\ArrayDataProvider();
         }
         
-        //3. Request to the web service and return result
+        //4. Request to the web service and return result
         $findResult = $this->find($sessionToken, $this->attributesToArray());
         
         if (is_string($findResult)) {
@@ -66,7 +68,8 @@ class UserSearch extends YiiUserModel {
                 'models' => $resultSet,
                 'pagination' => [
                     'pageSize' => $this->pageSize,
-                    'totalCount' => $this->totalCount
+                    'totalCount' => $this->totalCount,
+                    'page' => $this->page
                 ],
                 //SILEX:info
                 //totalCount must be there too to get the pagination in GridView
@@ -81,10 +84,10 @@ class UserSearch extends YiiUserModel {
      */
     public function attributesToArray() {
         $elementForWebService = parent::attributesToArray();
-        // add page attribute
         if(isset($this->page)){
             $elementForWebService[WSConstants::PAGE] = $this->getPageForWS();
         }
+      
         return $elementForWebService;
     }
     
@@ -101,5 +104,51 @@ class UserSearch extends YiiUserModel {
             }
         } 
         return $toReturn;
+    }
+    
+    /**
+     * Change the page depending on parameters
+     * if parameters are new, page number is set to one on the web client and
+     *    on page zero for the WS
+     * else the latest page number searched is given
+     * @param array $params paramters send by Yii2 send by the page
+     */
+    private function checkParameters($params) {
+        // get class name
+        $session = \Yii::$app->session;
+        $className = get_class();
+        $classNameExploded = explode('\\', $className);
+        $class = end($classNameExploded);
+
+        // on first page loading
+        if (isset($params[$class])) {
+            // save old parameters
+            if (!isset($session[$class])) {
+                $session[$class] = $params[$class];
+            }
+            // compare old and new parameters
+            $parametersOld = array_filter($session[$class]);
+            $parametersNew = array_filter($params[$class]);
+            $parametersDiff = array_diff($parametersNew, $parametersOld);
+            // define the right page
+            // if no modification from users load the page requested
+            // if there is a modification page number one is load
+            if (count($parametersDiff) != 0 || (count($parametersDiff) != 0 && count($parametersNew) == 0)) {
+                // add page attribute
+                $this->page = 1;
+            } else {
+                if (isset($params[YiiModelsConstants::PAGE])) {
+                    $this->page = $params[YiiModelsConstants::PAGE];
+                }
+            }
+            // save new parameters for the next checks
+            $session[$class] = $params[$class];
+        } else {
+            // if page two request on the first load
+            // not necessary but it's a security
+            if (isset($params[YiiModelsConstants::PAGE])) {
+                $this->page = $params[YiiModelsConstants::PAGE];
+            }
+        }
     }
 }

--- a/models/yiiModels/UserSearch.php
+++ b/models/yiiModels/UserSearch.php
@@ -84,6 +84,8 @@ class UserSearch extends YiiUserModel {
      */
     public function attributesToArray() {
         $elementForWebService = parent::attributesToArray();
+        
+        // add page attribute for WS paramaters
         if(isset($this->page)){
             $elementForWebService[WSConstants::PAGE] = $this->getPageForWS();
         }


### PR DESCRIPTION
- Showing correct pagination parameters when only one user is returned
- Fixes issue due to the use of search parameters from another page than the first (paginiation conflict)
References OpenSILEX/phis-ws#125