### PR TITLE
Fix weird star position of the "password" field in the login page 

### DIFF
--- a/web/css/site.css
+++ b/web/css/site.css
@@ -144,6 +144,12 @@ form div.required label.control-label:after {
 }
 /*\SILEX:required*/
 
+/*SILEX:required*/
+label.control-label {
+  padding-right: 5px;
+}
+/*\SILEX:required*/
+
 .ul_tiret {
    list-style-type: none;
 }


### PR DESCRIPTION
In English, in a plain screen, on the login page, the star that indicates that the password field is obligatory was below the field. I set it on the right. 