### PR TITLE
fix annotation creation date bug

### DIFF
--- a/models/yiiModels/YiiAnnotationModel.php
+++ b/models/yiiModels/YiiAnnotationModel.php
@@ -138,6 +138,7 @@ class YiiAnnotationModel extends WSActiveRecord {
     protected function arrayToAttributes($array) {
         $this->uri = $array[self::URI];
         $this->creator = $array[self::CREATOR];
+        $this->creationDate = (new \DateTime($array[self::CREATION_DATE]))->format(\DateTime::ATOM);
         $this->bodyValues = $array[self::BODY_VALUES];
         $this->motivatedBy = $array[self::MOTIVATED_BY];
         $this->targets = $array[self::TARGETS];


### PR DESCRIPTION
Annotation creation Date was not displayed from webservice value but was  always the current date
@see https://trello.com/c/FsjBvtwj/172-annotation-la-date-de-cr%C3%A9ation-est-la-date-actuelle