### PR TITLE
Fix OS type search during OS creation

### DIFF
--- a/controllers/ScientificObjectController.php
+++ b/controllers/ScientificObjectController.php
@@ -457,7 +457,7 @@ class ScientificObjectController extends Controller {
     private function getObjectTypeCompleteUri($objectType) {
         $objectTypesList = $this->getObjectsTypesUris();
         foreach ($objectTypesList as $objectTypeUri) {
-            if (strpos($objectTypeUri, $objectType)) {
+            if (preg_match("/". $objectType . "\b/", $objectTypeUri)) {
                 return $objectTypeUri;
             }
         }


### PR DESCRIPTION
If Root objects need to be created, the current search will fine the first occurence of  Root in any label.
This behaviour allows the creation of Rootstock instead of Root for example.